### PR TITLE
Enable powering off, restarting and termination of virtual machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.pytest_cache/
 __pycache__/
 *.py[cod]
 *$py.class
@@ -104,3 +105,4 @@ ENV/
 junit-test-results.xml
 
 .vscode/
+.idea/

--- a/chaosazure/machine/__init__.py
+++ b/chaosazure/machine/__init__.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import contextlib
+import os.path
+
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Secrets
+from msrestazure.azure_active_directory import ServicePrincipalCredentials
+
+__all__ = ["auth"]
+
+
+@contextlib.contextmanager
+def auth(secrets: Secrets) -> ServicePrincipalCredentials:
+    """
+    Attempt to load the Azure authentication information from a local
+    configuration file or the passed `configuration` mapping. The latter takes
+    precedence over the local configuration file.
+
+    If you provide a secrets dictionary, the returned mapping will
+    be created from their content. For instance, you could have:
+
+    Secrets mapping (in your experiment file):
+    ```json
+    {
+        "azure": {
+            "client_id": "AZURE_CLIENT_ID",
+            "client_secret": "AZURE_CLIENT_SECRET",
+            "tenant_id": "AZURE_TENANT_ID"
+        }
+    }
+    ```
+
+    The client_id, tenant_id, and client_secret content will be read
+    from the specified local environment variables, e.g. `AZURE_CLIENT_ID`,
+    `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` that you will have populated
+    before hand.
+    ```
+
+    Using this function goes as follows:
+
+    ```python
+    with auth(secrets) as cred:
+        azure_subscription_id = configuration['azure']['subscription_id']
+        resource_client = ResourceManagementClient(cred, azure_subscription_id)
+        compute_client = ComputeManagementClient(cred, azure_subscription_id)
+    ```
+    """
+    azure_secrets = secrets or {}
+
+    if not azure_secrets:
+        raise FailedActivity("Azure secrets not found")
+
+    client_id, client_secret, tenant_id = __fetch_secrets(azure_secrets)
+    __check_secrets(client_id, client_secret, tenant_id)
+    credentials = __generate_service_principal_credentials(client_id,
+                                                           client_secret,
+                                                           tenant_id)
+
+    yield credentials
+
+
+def __generate_service_principal_credentials(client_id, client_secret,
+                                             tenant_id):
+    credentials = ServicePrincipalCredentials(
+        client_id=client_id,
+        secret=client_secret,
+        tenant=tenant_id
+    )
+    return credentials
+
+
+def __check_secrets(client_id, client_secret, tenant_id):
+    if not client_id or not client_secret or not tenant_id:
+        raise FailedActivity("Client could not find Azure credentials")
+
+
+def __fetch_secrets(azure_secrets):
+    #
+    # fetch secrets from environment
+    #
+    client_id = os.getenv(azure_secrets.get('client_id'))
+    client_secret = os.getenv(azure_secrets.get('client_secret'))
+    tenant_id = os.getenv(azure_secrets.get('tenant_id'))
+
+    #
+    # fetch secrets from file content itself when empty
+    #
+    if not client_id:
+        client_id = azure_secrets.get('client_id')
+    if not client_secret:
+        client_secret = azure_secrets.get('client_secret')
+    if not tenant_id:
+        tenant_id = azure_secrets.get('tenant_id')
+    return client_id, client_secret, tenant_id

--- a/chaosazure/machine/actions.py
+++ b/chaosazure/machine/actions.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Dict
+
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.resource import ResourceManagementClient
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
+from chaosazure.machine import auth
+from chaosazure.machine.picker import pick_machine_randomly
+
+__all__ = ["delete_machine", "poweroff_machine", "restart_machine"]
+
+
+def delete_machine(configuration: Configuration = None,
+                   secrets: Secrets = None) -> Dict[str, Any]:
+    """
+    Delete machine randomly.
+    """
+    logger.debug(
+        'Starting delete_machine: configuration=[{}]'.format(configuration))
+
+    with auth(secrets) as cred:
+        compute_client, machine = __pick_chaos_machine(configuration, cred)
+
+        resource_group_name = machine.id.split('/')[4].lower()
+        logger.debug('Deletion chaos takes over for machine {}.{}'.format(
+            resource_group_name, machine.name))
+        async_restart = compute_client.virtual_machines.delete(
+            resource_group_name, machine.name)
+        result = async_restart.result()
+        logger.debug(
+            'Operation status for machine deletion: {}'.format(result.status))
+
+        return result
+
+
+def poweroff_machine(configuration: Configuration = None,
+                     secrets: Secrets = None) -> Dict[str, Any]:
+    """
+    Power off machine randomly.
+    """
+    logger.debug(
+        'Starting poweroff_machine: configuration=[{}]'.format(configuration))
+    with auth(secrets) as cred:
+        compute_client, machine = __pick_chaos_machine(configuration, cred)
+
+        resource_group_name = machine.id.split('/')[4].lower()
+        logger.debug('Powering off chaos takes over for machine {}.{}'.format(
+            resource_group_name, machine.name))
+        async_restart = compute_client.virtual_machines.power_off(
+            resource_group_name, machine.name)
+        result = async_restart.result()
+        logger.debug(
+            'Operation status for machine power off: {}'.format(result.status))
+
+        return result
+
+
+def restart_machine(configuration: Configuration = None,
+                    secrets: Secrets = None) -> Dict[str, Any]:
+    """
+    Restart machine randomly.
+    """
+    logger.debug(
+        'Starting restart_machine: configuration=[{}]'.format(configuration))
+    with auth(secrets) as cred:
+        compute_client, machine = __pick_chaos_machine(configuration, cred)
+
+        resource_group_name = machine.id.split('/')[4].lower()
+        logger.debug('Restarting chaos takes over for machine {}.{}'.format(
+            resource_group_name, machine.name))
+        async_restart = compute_client.virtual_machines.restart(
+            resource_group_name, machine.name)
+        result = async_restart.result()
+        logger.debug(
+            'Operation status for machine restart: {}'.format(result.status))
+
+        return result
+
+
+def __pick_chaos_machine(configuration, cred):
+    azure_subscription_id = configuration['azure']['subscription_id']
+    resource_client = ResourceManagementClient(cred, azure_subscription_id)
+    compute_client = ComputeManagementClient(cred, azure_subscription_id)
+    resource_groups_list = resource_client.resource_groups.list()
+    machines_list_all = compute_client.virtual_machines.list_all()
+    groups = configuration['azure']['resource_groups'].split(',')
+    machine = pick_machine_randomly(resource_groups_list, machines_list_all,
+                                    groups)
+    return compute_client, machine

--- a/chaosazure/machine/picker.py
+++ b/chaosazure/machine/picker.py
@@ -1,0 +1,30 @@
+import random
+
+from logzero import logger
+
+
+def pick_machine_randomly(subscribed_resource_groups, subscribed_instances,
+                          configured_resource_groups=None):
+    machines = pick_machines(subscribed_resource_groups, subscribed_instances,
+                             configured_resource_groups)
+    return random.choice(machines)
+
+
+def pick_machines(subscribed_resource_groups, subscribed_machines,
+                  configured_resource_groups=None):
+    machines = []
+
+    if not configured_resource_groups or configured_resource_groups is None:
+        logger.info("Client will pick all subscribed machines")
+        for machine in subscribed_machines:
+            machines.append(machine)
+    else:
+        for resource_group in subscribed_resource_groups:
+            if resource_group.name in configured_resource_groups:
+                for machine in subscribed_machines:
+                    machine_id_lower = machine.id.lower()
+                    group_id_lower = resource_group.id.lower()
+                    if machine_id_lower.startswith(group_id_lower):
+                        machines.append(machine)
+
+    return machines

--- a/chaosazure/machine/probes.py
+++ b/chaosazure/machine/probes.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.resource import ResourceManagementClient
+from chaoslib.types import Configuration, Secrets
+
+from chaosazure.machine import auth
+from chaosazure.machine.picker import pick_machines
+
+__all__ = ["describe_machines", "count_machines"]
+
+
+def describe_machines(configuration: Configuration = None,
+                      secrets: Secrets = None):
+    """
+    Describe Azure machines.
+    """
+    with auth(secrets) as cred:
+        machines = pick_subscribed_machines(configuration, cred)
+        return machines
+
+
+def count_machines(configuration: Configuration = None,
+                   secrets: Secrets = None) -> int:
+    """
+    Return count of Azure machines.
+    """
+    with auth(secrets) as cred:
+        machines = pick_subscribed_machines(configuration, cred)
+        return len(machines)
+
+
+def pick_subscribed_machines(configuration, cred):
+    azure_subscription_id = configuration['azure']['subscription_id']
+    resource_client = ResourceManagementClient(cred, azure_subscription_id)
+    compute_client = ComputeManagementClient(cred, azure_subscription_id)
+    resource_groups_list = resource_client.resource_groups.list()
+    machines_list_all = compute_client.virtual_machines.list_all()
+    rg = configuration['azure']['resource_groups'].split(',')
+    machines = pick_machines(resource_groups_list, machines_list_all, rg)
+    return machines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+azure-mgmt-resource==2.0.0
+azure-mgmt-compute~=2.0.0
 chaostoolkit-lib>=0.15.0
 dateparser
 logzero

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ url = 'http://chaostoolkit.org'
 license = 'Apache License Version 2.0'
 packages = [
     'chaosazure',
-    'chaosazure.fabric'
+    'chaosazure.fabric',
+    'chaosazure.machine'
 ]
 
 needs_pytest = set(['pytest', 'test']).intersection(sys.argv)

--- a/tests/machine/test_picker.py
+++ b/tests/machine/test_picker.py
@@ -1,0 +1,73 @@
+from chaosazure.machine.picker import pick_machines
+
+
+def test_pick_machines_with_empty_arguments():
+    subscribed_resource_groups = []
+    subscribed_machines = []
+    machines = pick_machines(subscribed_resource_groups, subscribed_machines)
+
+    assert len(machines) == 0
+
+
+def test_pick_machines_with_no_subscribed_machines():
+    subscribed_resource_groups = [
+        MyResourceGroup(id='1234/res_group_one', name='res_group_one'),
+        MyResourceGroup(id='1234/res_group_one', name='res_group_two')]
+    subscribed_machines = []
+    configured_resource_groups = 'res_group_one,res_group_two'.split(',')
+    machines = pick_machines(subscribed_resource_groups, subscribed_machines,
+                             configured_resource_groups)
+
+    assert len(machines) == 0
+
+
+def test_pick_machines_with_one_fitting_vm():
+    subscribed_resource_groups = [
+        MyResourceGroup(id='1234/res_group_one', name='res_group_one'),
+        MyResourceGroup(id='9876/res_group_two', name='res_group_two')]
+    subscribed_machines = [MyVirtualMachine(id='1234/res_group_one/myvmname')]
+    configured_resource_groups = 'res_group_one,res_group_two'.split(',')
+    machines = pick_machines(subscribed_resource_groups, subscribed_machines,
+                             configured_resource_groups)
+
+    assert len(machines) == 1
+
+
+def test_pick_machines_with_two_fitting_vm():
+    subscribed_resource_groups = [
+        MyResourceGroup(id='1234/res_group_one', name='res_group_one'),
+        MyResourceGroup(id='9876/res_group_two', name='res_group_two')]
+    subscribed_machines = [MyVirtualMachine(id='1234/res_group_one/myvmname'),
+                           MyVirtualMachine(id='9876/res_group_two/myvmname')]
+    configured_resource_groups = 'res_group_one,res_group_two'.split(',')
+    machines = pick_machines(subscribed_resource_groups, subscribed_machines,
+                             configured_resource_groups)
+
+    assert len(machines) == 2
+
+
+def test_pick_machines_with_multiple_vm_but_only_one_vm_fits():
+    subscribed_resource_groups = [
+        MyResourceGroup(id='1234/res_group_one', name='res_group_one'),
+        MyResourceGroup(id='9876/res_group_two', name='res_group_two')]
+    subscribed_machines = [MyVirtualMachine(id='1234/res_group_one/myvmname'),
+                           MyVirtualMachine(
+                               id='5555/res_group_other/myvmname')]
+    configured_resource_groups = 'res_group_one,res_group_two'.split(',')
+    machines = pick_machines(subscribed_resource_groups, subscribed_machines,
+                             configured_resource_groups)
+
+    assert len(machines) == 1
+
+
+class MyVirtualMachine:
+
+    def __init__(self, id):
+        self.id = id
+
+
+class MyResourceGroup:
+
+    def __init__(self, id, name):
+        self.id = id
+        self.name = name


### PR DESCRIPTION
This commit enables the Chaostoolkit to spread chaos actions on Azure
virtual machines. Power off, restart and terminate virtual machines
randomly.

With the probes you can collect relevant measures on your virtual
machines.

Resolves: #3 

Signed-off-by: Bugra Derre <bugra.derre@gmail.com>