### PR TITLE
Enable fine-granular filter queries for probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Introduce Azure CLI
 -   Install Azure CLI resource-graph extension if it is not installed
 -   Enable filtering of Azure infrastructure resources, e.g. virtual machines
+-   Enable filtering of Azure infrastructure resources in probes
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.2.0...HEAD
 

--- a/tests/machine/test_probes.py
+++ b/tests/machine/test_probes.py
@@ -1,0 +1,20 @@
+from chaosazure.machine.probes import count_machines
+
+CONFIG = {
+    "azure": {
+        "subscription_id": "3ca1a05a-6888-4b19-bfb7-73556675e8e7",
+        "resource_groups": "MC_chaosMonkeyGroup_chaosMonkeyAks_centralus"
+    }
+}
+
+SECRETS = {
+    "client_id": "8d997de9-9daf-43a1-98c3-04f41a64b62f",
+    "client_secret": "oIAznMsOFRazS/S603EF30oDS7mivghDUQd14qjOotI=",
+    "tenant_id": "9652d7c2-1ccf-4940-8151-4a92bd474ed0"
+}
+
+
+def test_network_action():
+    filter = "where resourceGroup=~'MC_chaosMonkeyGroup_chaosMonkeyAks_centralus'"
+
+    count_machines(configuration=CONFIG, secrets=SECRETS, filter=filter)


### PR DESCRIPTION
Instead of providing resource groups in the configuration file, the user
is now able to provide filter queries in probes. The filter queries are
passed locally to the probe. This commit unifies the handling of probes
with the provided actions for virtual machines.

Resolves: #23
Signed-off-by: Auli Rahnasto <auli.rahnasto@gmx.de>