### PR TITLE
Enable fine-granular filter queries for probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Introduce Azure CLI
 -   Install Azure CLI resource-graph extension if it is not installed
 -   Enable filtering of Azure infrastructure resources, e.g. virtual machines
+-   Enable filtering of Azure infrastructure resources in probes
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.2.0...HEAD
 


### PR DESCRIPTION
Instead of providing resource groups in the configuration file, the user
is now able to provide filter queries in probes. The filter queries are
passed locally to the probe. This commit unifies the handling of probes
with the provided actions for virtual machines.

Resolves: #23
Signed-off-by: Auli Rahnasto <auli.rahnasto@gmx.de>