### PR TITLE
Introduce rollback action for virtual machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Introduce actions on Azure Virtual Machine Scalesets (VMSS), like stopping, restarting, and
     deallocating AKS nodes
 -   Emphasize the risk of deleting actions in the docstrings
+-   Introduce rollback action for virtual machines
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.2.0...HEAD
 

--- a/chaosazure/machine/commands.py
+++ b/chaosazure/machine/commands.py
@@ -21,3 +21,11 @@ def restart_machine_command(choice):
                '-n', choice['name']]
 
     return command
+
+
+def start_machine_command(choice):
+    command = ['vm', 'start',
+               '-g', choice['resourceGroup'],
+               '-n', choice['name']]
+
+    return command

--- a/tests/machine/test_machine_commands.py
+++ b/tests/machine/test_machine_commands.py
@@ -1,5 +1,5 @@
 from chaosazure.machine.commands import delete_machine_command, \
-    poweroff_machine_command, restart_machine_command
+    poweroff_machine_command, restart_machine_command, start_machine_command
 
 TESTED_RESOURCE = "Microsoft.ContainerService/managedClusters"
 
@@ -39,5 +39,17 @@ def test_restart_machine_command():
 
     assert len(command) == 6
     assert command[1] == 'restart'
+    assert command[3] == machine['resourceGroup']
+    assert command[5] == machine['name']
+
+
+def test_start_machine_command():
+    machine = {
+        'name': 'myname',
+        'resourceGroup': 'myresourcegroup'
+    }
+    command = start_machine_command(machine)
+    assert len(command) == 6
+    assert command[1] == 'start'
     assert command[3] == machine['resourceGroup']
     assert command[5] == machine['name']


### PR DESCRIPTION
This commit enables us to rollback all stopped machines during a chaos
experiment and start them again.

Resolves: #32
Signed-off-by: Schneider, Matthias (415) <matthias.b.schneider@daimler.com>