### PR TITLE
Remove redundant environment variable check for security configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.3.1...HEAD
 
+-   Refactoring: Remove redundant check for security variables  from environment
+
 ## [0.3.1][] - 2019-06-01
 
 [0.3.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.3.0...0.3.1


### PR DESCRIPTION
Environment variables are already checked by the chaostoolkit-lib. There
is no need to check it in the extension.

Resolves: #43
Signed-off-by: Derre, Bugra (415) <bugra.derre@daimler.com>