### PR TITLE
Remove not required azure-mgmt-* dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -   Introduce rollback action for virtual machines
 -   Separate service fabric functionality from the chaostoolkit-azure extension
 -   Introduce CPU stress action for VMs
+-   Remove not used azure-mgmt dependencies (#53)
 
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.3.1...HEAD

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-azure-mgmt
+chaostoolkit-lib>==1.1.2
+azure-mgmt-compute
 azure-mgmt-resourcegraph
-chaostoolkit-lib>=0.15.0
 dateparser
 logzero
 requests


### PR DESCRIPTION
It is not required to add azure-mgmt with all its dependencies as most
of the packages are not used. For now only compute and resource graph
are used.

This closes #53

Signed-off-by: Kaszubski, Marcin <marcin.kaszubski@live.com>