### PR TITLE
Fixed the MS Azure REST API version 2019-04-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased][]
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.4.0...HEAD
 
+-  Fixed the new MS Azure REST API version 2019-04-01
+
 ## [0.4.0][] - 2019-04-15
 
 [0.4.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.3.1...0.4.0

--- a/chaosazure/rgraph/mapper.py
+++ b/chaosazure/rgraph/mapper.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+
+def to_dicts(table, version):
+    results = []
+    version_date = datetime.strptime(version, '%Y-%m-%d').date()
+
+    if version_date >= datetime.strptime('2019-04-01', '%Y-%m-%d').date():
+        for row in table['rows']:
+            result = {}
+            for col_index in range(len(table['columns'])):
+                result[table['columns'][col_index]['name']] = row[col_index]
+            results.append(result)
+
+    else:
+        for row in table.rows:
+            result = {}
+            for col_index in range(len(table.columns)):
+                result[table.columns[col_index].name] = row[col_index]
+            results.append(result)
+
+    return results

--- a/chaosazure/rgraph/resource_graph.py
+++ b/chaosazure/rgraph/resource_graph.py
@@ -2,6 +2,7 @@ from azure.mgmt.resourcegraph import ResourceGraphClient
 from azure.mgmt.resourcegraph.models import QueryRequest
 
 from chaosazure import auth
+from chaosazure.rgraph.mapper import to_dicts
 
 
 def fetch_resources(query, resource_type, secrets, configuration):
@@ -11,18 +12,8 @@ def fetch_resources(query, resource_type, secrets, configuration):
         client = ResourceGraphClient(credentials=cred)
         resources = client.resources(query)
 
-        results = __to_dicts(resources.data)
+        results = to_dicts(resources.data, client.api_version)
         return results
-
-
-def __to_dicts(table):
-    results = []
-    for row in table.rows:
-        result = {}
-        for col_index in range(len(table.columns)):
-            result[table.columns[col_index].name] = row[col_index]
-        results.append(result)
-    return results
 
 
 def __create_resource_graph_query(query, resource_type, configuration):

--- a/tests/aks/test_aks_actions.py
+++ b/tests/aks/test_aks_actions.py
@@ -29,7 +29,7 @@ def test_restart_node_with_no_nodes(fetch):
         fetch.return_value = resource_list
         delete_node(None, None, None)
 
-    assert "No AKS clusters found" in str(x)
+    assert "No AKS clusters found" in str(x.value)
 
 
 @patch('chaosazure.aks.actions.fetch_resources', autospec=True)
@@ -48,7 +48,7 @@ def test_restart_node_with_no_nodes(fetch):
         fetch.return_value = resource_list
         stop_node(None, None, None)
 
-    assert "No AKS clusters found" in str(x)
+    assert "No AKS clusters found" in str(x.value)
 
 
 @patch('chaosazure.aks.actions.fetch_resources', autospec=True)
@@ -67,4 +67,4 @@ def test_restart_node_with_no_nodes(fetch):
         fetch.return_value = resource_list
         restart_node(None, None, None)
 
-    assert "No AKS clusters found" in str(x)
+    assert "No AKS clusters found" in str(x.value)

--- a/tests/machine/test_machine_actions.py
+++ b/tests/machine/test_machine_actions.py
@@ -85,7 +85,7 @@ def test_delete_machine_with_no_machines(fetch):
         fetch.return_value = resource_list
         delete_machines(None, None, None)
 
-    assert "No virtual machines found" in str(x)
+    assert "No virtual machines found" in str(x.value)
 
 
 @patch('chaosazure.machine.actions.fetch_resources', autospec=True)
@@ -95,7 +95,7 @@ def test_stop_machine_with_no_machines(fetch):
         fetch.return_value = resource_list
         stop_machines(None, None, None)
 
-    assert "No virtual machines found" in str(x)
+    assert "No virtual machines found" in str(x.value)
 
 
 @patch('chaosazure.machine.actions.__fetch_machines', autospec=True)
@@ -169,7 +169,7 @@ def test_restart_machine_with_no_machines(fetch):
         fetch.return_value = resource_list
         restart_machines(None, None, None)
 
-    assert "No virtual machines found" in str(x)
+    assert "No virtual machines found" in str(x.value)
 
 
 @patch('chaosazure.machine.actions.fetch_resources', autospec=True)
@@ -179,7 +179,7 @@ def test_start_machine_with_no_machines(fetch):
         fetch.return_value = resource_list
         start_machines()
 
-    assert "No virtual machines found" in str(x)
+    assert "No virtual machines found" in str(x.value)
 
 
 @patch('chaosazure.machine.actions.__fetch_machines', autospec=True)

--- a/tests/vmss/test_vmss_actions.py
+++ b/tests/vmss/test_vmss_actions.py
@@ -42,7 +42,7 @@ def test_deallocate_vmss_having_no_vmss_instances(fetch_instances, fetch_vmss):
 
         deallocate_vmss(None, None, None)
 
-    assert "No virtual machine scale set instances found" in str(x)
+    assert "No virtual machine scale set instances found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -52,7 +52,7 @@ def test_deallocate_vmss_having_no_vmss(fetch):
         fetch.return_value = resource_list
         deallocate_vmss(None, None, None)
 
-    assert "No virtual machine scale sets found" in str(x)
+    assert "No virtual machine scale sets found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -82,7 +82,7 @@ def test_stop_vmss_having_no_vmss_instances(fetch_instances, fetch_vmss):
 
         stop_vmss(None, None, None)
 
-    assert "No virtual machine scale set instances found" in str(x)
+    assert "No virtual machine scale set instances found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -92,7 +92,7 @@ def test_stop_vmss_having_no_vmss(fetch):
         fetch.return_value = resource_list
         stop_vmss(None, None, None)
 
-    assert "No virtual machine scale sets found" in str(x)
+    assert "No virtual machine scale sets found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -122,7 +122,7 @@ def test_restart_vmss_having_no_vmss_instances(fetch_instances, fetch_vmss):
 
         restart_vmss(None, None, None)
 
-    assert "No virtual machine scale set instances found" in str(x)
+    assert "No virtual machine scale set instances found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -132,7 +132,7 @@ def test_restart_vmss_having_no_vmss(fetch):
         fetch.return_value = resource_list
         restart_vmss(None, None, None)
 
-    assert "No virtual machine scale sets found" in str(x)
+    assert "No virtual machine scale sets found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -162,7 +162,7 @@ def test_delete_vmss_having_no_vmss_instances(fetch_instances, fetch_vmss):
 
         delete_vmss(None, None, None)
 
-    assert "No virtual machine scale set instances found" in str(x)
+    assert "No virtual machine scale set instances found" in str(x.value)
 
 
 @patch('chaosazure.vmss.actions.fetch_resources', autospec=True)
@@ -172,7 +172,7 @@ def test_delete_vmss_having_no_vmss(fetch):
         fetch.return_value = resource_list
         delete_vmss(None, None, None)
 
-    assert "No virtual machine scale sets found" in str(x)
+    assert "No virtual machine scale sets found" in str(x.value)
 
 
 class MockVirtualMachineScaleSetVMsOperations(object):


### PR DESCRIPTION
The MS Azure REST API introduced a new version 2019-04-01. This version
does not work with the chaostoolkit-azure. This commit handles the new
version and also the older API versions.

Resolves: #59
Signed-off-by: Holzmann, Lucas (415) <lucas.holzmann@daimler.com>