### PR TITLE
Introduce new feature: network latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased][]
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.5.0...HEAD
 
+- Added the network_latency feature: disturb the network of the VM, adding some latency for a time period 
+(defaults to a 200 +/- 50ms latency for 1 minute). Only works on Linux machines for now.
+
 ## [0.5.0][] - 2019-07-05
 
 [0.5.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.4.0...0.5.0

--- a/chaosazure/machine/scripts/network_latency.sh
+++ b/chaosazure/machine/scripts/network_latency.sh
@@ -1,0 +1,6 @@
+# Script for NetworkLatency Chaos Monkey
+
+# Adds ${delay}ms +- ${jitter}ms of latency to each packet for $duration seconds
+sudo tc qdisc add dev eth0 root netem delay ${delay}ms ${jitter}ms
+sleep $duration
+sudo tc qdisc del dev eth0 root

--- a/tests/machine/test_machine_actions.py
+++ b/tests/machine/test_machine_actions.py
@@ -7,7 +7,7 @@ from chaoslib.exceptions import FailedActivity
 from unittest.mock import MagicMock, patch, mock_open
 
 from chaosazure.machine.actions import restart_machines, stop_machines, \
-    delete_machines, start_machines, stress_cpu, fill_disk
+    delete_machines, start_machines, stress_cpu, fill_disk, network_latency
 
 CONFIG = {
     "azure": {
@@ -422,6 +422,85 @@ def test_fill_disk_timeout(init, fetch, open):
     poller.result.return_value = None
 
     # act & assert
-    with pytest.raises(FailedActivity, match=r'stress_cpu operation did not '
+    with pytest.raises(FailedActivity, match=r'fill_disk operation did not '
                                              r'finish on time'):
-        stress_cpu("where name=='some_windows_machine'", 60, 100)
+        fill_disk("where name=='some_windows_machine'", 60, 100)
+
+
+@patch("builtins.open", new_callable=mock_open, read_data="script")
+@patch('chaosazure.machine.actions.fetch_resources', autospec=True)
+@patch('chaosazure.machine.actions.__compute_mgmt_client', autospec=True)
+def test_network_latency_on_lnx(init, fetch, open):
+    # arrange mocks
+    client = MagicMock()
+    init.return_value = client
+    resource = __get_resource(os_type='Linux')
+    resource_list = [resource]
+    fetch.return_value = resource_list
+    # run command mocks
+    poller = MagicMock()
+    client.virtual_machines.run_command.return_value = poller
+    result = MagicMock(spec=RunCommandResult)
+    poller.result.return_value = result
+    result.value = [InstanceViewStatus()]
+
+    # act
+    network_latency(filter="where name=='some_linux_machine'", duration=60,
+                    delay=200, jitter=50, configuration=CONFIG,
+                    secrets=SECRETS)
+
+    # assert
+    fetch.assert_called_with(
+        "where name=='some_linux_machine'",
+        "Microsoft.Compute/virtualMachines", SECRETS, CONFIG)
+    open.assert_called_with(AnyStringWith("network_latency.sh"))
+    client.virtual_machines.run_command.assert_called_with(
+        resource['resourceGroup'],
+        resource['name'],
+        {
+            'command_id': 'RunShellScript',
+            'script': ['script'],
+            'parameters': [
+                {'name': 'duration', 'value': 60},
+                {'name': 'delay', 'value': 200},
+                {'name': 'jitter', 'value': 50}
+            ]
+        })
+
+
+@patch("builtins.open", new_callable=mock_open, read_data="script")
+@patch('chaosazure.machine.actions.fetch_resources', autospec=True)
+@patch('chaosazure.machine.actions.__compute_mgmt_client', autospec=True)
+def test_network_latency_invalid_resource(init, fetch, open):
+    # arrange mocks
+    client = MagicMock()
+    init.return_value = client
+    resource = __get_resource(os_type='Invalid')
+    resource_list = [resource]
+    fetch.return_value = resource_list
+
+    # act
+    with pytest.raises(Exception) as ex:
+        fill_disk("where name=='some_machine'", 60, 200, 50)
+    assert str(ex.value) == 'Unknown OS Type: invalid'
+
+
+@patch("builtins.open", new_callable=mock_open, read_data="script")
+@patch('chaosazure.machine.actions.fetch_resources', autospec=True)
+@patch('chaosazure.machine.actions.__compute_mgmt_client', autospec=True)
+def test_network_latency_timeout(init, fetch, open):
+    # arrange mocks
+    client = MagicMock()
+    init.return_value = client
+    resource = __get_resource(os_type='Linux')
+    resource_list = [resource]
+    fetch.return_value = resource_list
+    # run command mocks
+    poller = MagicMock()
+    client.virtual_machines.run_command.return_value = poller
+    poller.result.return_value = None
+
+    # act & assert
+    with pytest.raises(FailedActivity, match=r'network_latency operation did not '
+                                             r'finish on time'):
+        network_latency("where name=='some_linux_machine'", 60, 200, 50)


### PR DESCRIPTION
Implement a new feature on Linux devices allowing the user to
modify its network latency. Windows is not supported yet. The
feature adds a rule thanks to the tc netem command, waits for
the appropriate duration and then resets the network settings.

Resolves: #63

Signed-off-by: Holzmann, Lucas (415) <lucas.holzmann@daimler.com>