### PR TITLE
Return output results for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][]
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.7.0...HEAD
 
+- Return output from activities
 - Allow user to load more than one VMSS instance for VMSS actions
 - Update list of unsupported scripts for Windows VM
 - Added network latency operation vor VMSS instances

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include requirements-dev.txt
 include LICENSE
 include CHANGELOG.md
 include pytest.ini
-include chaosazure/machine/scripts/*
+include chaosazure/common/scripts/*

--- a/chaosazure/aks/actions.py
+++ b/chaosazure/aks/actions.py
@@ -34,7 +34,7 @@ def delete_node(filter: str = None,
             configuration, filter))
 
     query = node_resource_group_query(filter, configuration, secrets)
-    delete_machines(query, configuration, secrets)
+    return delete_machines(query, configuration, secrets)
 
 
 def stop_node(filter: str = None,
@@ -56,7 +56,7 @@ def stop_node(filter: str = None,
             configuration, filter))
 
     query = node_resource_group_query(filter, configuration, secrets)
-    stop_machines(query, configuration, secrets)
+    return stop_machines(query, configuration, secrets)
 
 
 def restart_node(filter: str = None,
@@ -78,7 +78,7 @@ def restart_node(filter: str = None,
             configuration, filter))
 
     query = node_resource_group_query(filter, configuration, secrets)
-    restart_machines(query, configuration, secrets)
+    return restart_machines(query, configuration, secrets)
 
 
 ###############################################################################

--- a/chaosazure/common/cleanse.py
+++ b/chaosazure/common/cleanse.py
@@ -1,0 +1,40 @@
+def machine(resource: dict) -> dict:
+    """
+    Free the virtual machine dictionary from unwanted keys listed below.
+    """
+    cleanse = [
+        "properties"
+    ]
+
+    return __cleanse(cleanse, resource)
+
+
+def vmss(resource: dict) -> dict:
+    """
+    Free the VMSS dictionary from unwanted keys listed below.
+    """
+    cleanse = [
+        "properties", "instances"
+    ]
+
+    return __cleanse(cleanse, resource)
+
+
+def vmss_instance(resource: dict) -> dict:
+    """
+    Free the VMSS instance from unwanted keys listed below.
+    """
+    cleanse = [
+        "hardware_profile", "storage_profile", "network_profile",
+        "os_profile", "network_profile_configuration", "resources"
+    ]
+
+    return __cleanse(cleanse, resource)
+
+
+def __cleanse(cleanse_list: [], resource: dict) -> dict:
+    for key in cleanse_list:
+        if key in resource:
+            del resource[key]
+
+    return resource

--- a/chaosazure/common/resources/graph.py
+++ b/chaosazure/common/resources/graph.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List
 
 from azure.mgmt.resourcegraph.models \
     import QueryRequest, ErrorResponseException
@@ -25,7 +26,6 @@ def fetch_resources(input_query: str, resource_type: str,
         if e.inner_exception.error.details:
             for d in e.inner_exception.error.details:
                 msg += ": " + str(d)
-        logger.error(msg)
         raise InterruptExecution(msg)
 
     # prepare results
@@ -52,7 +52,7 @@ def __query_from(resource_type, query) -> str:
     return "Resources | {}".format(result)
 
 
-def __to_dicts(table, version):
+def __to_dicts(table, version) -> List[dict]:
     results = []
     version_date = datetime.strptime(version, '%Y-%m-%d').date()
 

--- a/chaosazure/vmss/fetcher.py
+++ b/chaosazure/vmss/fetcher.py
@@ -114,12 +114,7 @@ def __is_criteria_matched(instance: dict,
 def __parse_vmss_instances_result(instances, vmss: dict) -> List[Dict]:
     results = []
     for instance in instances:
-        m = {
-            'name': vmss['name'],
-            'resourceGroup': vmss['resourceGroup'],
-            'instanceId': instance.instance_id,
-            'osType': instance.storage_profile.os_disk.os_type.lower(),
-            'type': instance.type
-        }
-        results.append(m)
+        instance_as_dict = instance.as_dict()
+        instance_as_dict['scale_set'] = vmss['name']
+        results.append(instance_as_dict)
     return results

--- a/chaosazure/vmss/records.py
+++ b/chaosazure/vmss/records.py
@@ -1,0 +1,21 @@
+from calendar import timegm
+from datetime import datetime
+
+
+class Records:
+    elements = []
+
+    def __init__(self):
+        self.elements = []
+
+    def add(self, element: dict):
+        element['performed_at'] = timegm(datetime.utcnow().utctimetuple())
+        self.elements.append(element)
+
+    def output(self):
+        return self.elements
+
+    def output_as_dict(self, key: str):
+        return {
+            key: self.elements
+        }

--- a/tests/data/vmss_provider.py
+++ b/tests/data/vmss_provider.py
@@ -3,16 +3,15 @@ from chaosazure.vmss.constants import RES_TYPE_VMSS_VM, RES_TYPE_VMSS
 
 def provide_instance():
     return {
-        'name': 'chaos-machine',
-        'resourceGroup': 'rg',
-        'instanceId': '0',
+        'name': 'chaos-pool_0',
+        'instance_id': '0',
         'type': RES_TYPE_VMSS_VM,
     }
 
 
 def provide_scale_set():
     return {
-        'name': 'chaos-machine',
+        'name': 'chaos-pool',
         'resourceGroup': 'rg',
         'type': RES_TYPE_VMSS,
     }

--- a/tests/machine/test_machine_actions.py
+++ b/tests/machine/test_machine_actions.py
@@ -229,7 +229,7 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch):
         "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'cpu_stress_test')
     mocked_command_run.assert_called_with(
-        machine, 120,
+        machine['resourceGroup'], machine, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['cpu_stress_test.sh'],
@@ -268,7 +268,7 @@ def test_fill_disk(mocked_command_run, mocked_command_prepare_path,
         "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'fill_disk')
     mocked_command_run.assert_called_with(
-        machine, 120,
+        machine['resourceGroup'], machine, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['fill_disk.sh'],
@@ -306,7 +306,7 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch):
         "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'network_latency')
     mocked_command_run.assert_called_with(
-        machine, 120,
+        machine['resourceGroup'], machine, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['network_latency.sh'],
@@ -343,7 +343,7 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch):
         "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'burn_io')
     mocked_command_run.assert_called_with(
-        machine, 120,
+        machine['resourceGroup'], machine, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['burn_io.sh'],

--- a/tests/vmss/test_vmss_actions.py
+++ b/tests/vmss/test_vmss_actions.py
@@ -1,28 +1,9 @@
-from unittest.mock import MagicMock, patch
-
-import pytest
-from chaoslib.exceptions import FailedActivity
+from unittest.mock import patch
 
 import chaosazure
 from chaosazure.vmss.actions import delete_vmss, restart_vmss, stop_vmss, \
     deallocate_vmss, stress_vmss_instance_cpu, network_latency, burn_io, fill_disk
 from tests.data import config_provider, secrets_provider, vmss_provider
-
-resource_vmss = {
-    'name': 'chaos-vmss',
-    'resourceGroup': 'rg'}
-
-resource_vmss_instance_1 = {
-    'name': 'chaos-vmss-instance',
-    'instanceId': '1'}
-
-resource_vmss_instance_2 = {
-    'name': 'chaos-vmss-instance-2',
-    'instanceId': '2'}
-
-resource_vmss_instance_3 = {
-    'name': 'chaos-vmss-instance-3',
-    'instanceId': '3'}
 
 
 @patch('chaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -46,11 +27,12 @@ def test_deallocate_vmss(client, fetch_instances, fetch_vmss):
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
 @patch('chaosazure.vmss.actions.init_client', autospec=True)
 def test_stop_vmss(client, fetch_instances, fetch_vmss):
-    vmss_list = [resource_vmss]
-    fetch_vmss.return_value = vmss_list
-
-    instances_list = [resource_vmss_instance_1]
-    fetch_instances.return_value = instances_list
+    scale_set = vmss_provider.provide_scale_set()
+    scale_sets = [scale_set]
+    instance = vmss_provider.provide_instance()
+    instances = [instance]
+    fetch_vmss.return_value = scale_sets
+    fetch_instances.return_value = instances
 
     client.return_value = MockComputeManagementClient()
 
@@ -61,11 +43,12 @@ def test_stop_vmss(client, fetch_instances, fetch_vmss):
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
 @patch('chaosazure.vmss.actions.init_client', autospec=True)
 def test_restart_vmss(client, fetch_instances, fetch_vmss):
-    vmss_list = [resource_vmss]
-    fetch_vmss.return_value = vmss_list
-
-    instances_list = [resource_vmss_instance_1]
-    fetch_instances.return_value = instances_list
+    scale_set = vmss_provider.provide_scale_set()
+    scale_sets = [scale_set]
+    instance = vmss_provider.provide_instance()
+    instances = [instance]
+    fetch_vmss.return_value = scale_sets
+    fetch_instances.return_value = instances
 
     client.return_value = MockComputeManagementClient()
 
@@ -76,11 +59,12 @@ def test_restart_vmss(client, fetch_instances, fetch_vmss):
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
 @patch('chaosazure.vmss.actions.init_client', autospec=True)
 def test_delete_vmss(client, fetch_instances, fetch_vmss):
-    vmss_list = [resource_vmss]
-    fetch_vmss.return_value = vmss_list
-
-    instances_list = [resource_vmss_instance_1]
-    fetch_instances.return_value = instances_list
+    scale_set = vmss_provider.provide_scale_set()
+    scale_sets = [scale_set]
+    instance = vmss_provider.provide_instance()
+    instances = [instance]
+    fetch_vmss.return_value = scale_sets
+    fetch_instances.return_value = instances
 
     client.return_value = MockComputeManagementClient()
 
@@ -138,7 +122,7 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch_instance, 
     fetch_instance.assert_called_with(scale_set, None, config, secrets)
     mocked_command_prepare.assert_called_with(instance, 'cpu_stress_test')
     mocked_command_run.assert_called_with(
-        instance, 120,
+        scale_set['resourceGroup'], instance, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['cpu_stress_test.sh'],
@@ -179,7 +163,7 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch_insta
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_prepare.assert_called_with(instance, 'network_latency')
     mocked_command_run.assert_called_with(
-        instance, 120,
+        scale_set['resourceGroup'], instance, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['network_latency.sh'],
@@ -219,7 +203,7 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fe
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_run.assert_called_with(
-        instance, 120,
+        scale_set['resourceGroup'], instance, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['burn_io.sh'],
@@ -261,7 +245,7 @@ def test_fill_disk(mocked_command_run, mocked_command_prepare,
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_run.assert_called_with(
-        instance, 120,
+        scale_set['resourceGroup'], instance, 120,
         {
             'command_id': 'RunShellScript',
             'script': ['fill_disk.sh'],

--- a/tests/vmss/test_vmss_fetcher.py
+++ b/tests/vmss/test_vmss_fetcher.py
@@ -18,7 +18,7 @@ def test_succesful_fetch_vmss(mocked_fetch_vmss):
     result = fetch_vmss(None, None, None)
 
     assert len(result) == 1
-    assert result[0].get('name') == 'chaos-machine'
+    assert result[0].get('name') == 'chaos-pool'
 
 
 @patch('chaosazure.vmss.fetcher.fetch_resources', autospec=True)
@@ -41,8 +41,8 @@ def test_succesful_fetch_instances_without_instance_criteria(mocked_fetch_instan
     result = fetch_instances(scale_set, None, None, None)
 
     assert len(result) == 1
-    assert result[0].get('name') == 'chaos-machine'
-    assert result[0].get('instanceId') == '0'
+    assert result[0].get('name') == 'chaos-pool_0'
+    assert result[0].get('instance_id') == '0'
 
 
 @patch.object(chaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
@@ -60,84 +60,90 @@ def test_empty_fetch_instances_without_instance_criteria(mocked_fetch_instances)
 def test_succesful_fetch_instances_with_instance_criteria_for_instance0(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
-    instance_0['instanceId'] = '0'
+    instance_0['instance_id'] = '0'
     instance_1 = vmss_provider.provide_instance()
-    instance_1['instanceId'] = '1'
+    instance_1['instance_id'] = '1'
     instance_2 = vmss_provider.provide_instance()
-    instance_2['instanceId'] = '2'
+    instance_2['instance_id'] = '2'
     instances = [instance_0, instance_1, instance_2]
     mocked_fetch_instances.return_value = instances
     scale_set = vmss_provider.provide_scale_set()
 
     # fire
-    result = fetch_instances(scale_set, [{'instanceId': '0'}], None, None)
+    result = fetch_instances(scale_set, [{'instance_id': '0'}], None, None)
 
     # assert
     assert len(result) == 1
-    assert result[0].get('name') == 'chaos-machine'
-    assert result[0].get('instanceId') == '0'
+    assert result[0].get('name') == 'chaos-pool_0'
+    assert result[0].get('instance_id') == '0'
 
 
 @patch.object(chaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_with_instance_criteria_for_instance0_instance_2(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
-    instance_0['instanceId'] = '0'
+    instance_0['instance_id'] = '0'
+    instance_0['name'] = 'chaos-pool_0'
     instance_1 = vmss_provider.provide_instance()
-    instance_1['instanceId'] = '1'
+    instance_1['instance_id'] = '1'
+    instance_1['name'] = 'chaos-pool_1'
     instance_2 = vmss_provider.provide_instance()
-    instance_2['instanceId'] = '2'
+    instance_2['instance_id'] = '2'
+    instance_2['name'] = 'chaos-pool_2'
     instances = [instance_0, instance_1, instance_2]
     mocked_fetch_instances.return_value = instances
     scale_set = vmss_provider.provide_scale_set()
 
     # fire
-    result = fetch_instances(scale_set, [{'instanceId': '0'}, {'instanceId': '2'}], None, None)
+    result = fetch_instances(scale_set, [{'instance_id': '0'}, {'instance_id': '2'}], None, None)
 
     # assert
     assert len(result) == 2
-    assert result[0].get('name') == 'chaos-machine'
-    assert result[0].get('instanceId') == '0'
-    assert result[1].get('name') == 'chaos-machine'
-    assert result[1].get('instanceId') == '2'
+    assert result[0].get('name') == 'chaos-pool_0'
+    assert result[0].get('instance_id') == '0'
+    assert result[1].get('name') == 'chaos-pool_2'
+    assert result[1].get('instance_id') == '2'
 
 
 @patch.object(chaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_with_instance_criteria_for_all_instances(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
-    instance_0['instanceId'] = '0'
+    instance_0['instance_id'] = '0'
+    instance_0['name'] = 'chaos-pool_0'
     instance_1 = vmss_provider.provide_instance()
-    instance_1['instanceId'] = '1'
+    instance_1['instance_id'] = '1'
+    instance_1['name'] = 'chaos-pool_1'
     instance_2 = vmss_provider.provide_instance()
-    instance_2['instanceId'] = '2'
+    instance_2['instance_id'] = '2'
+    instance_2['name'] = 'chaos-pool_2'
     instances = [instance_0, instance_1, instance_2]
     mocked_fetch_instances.return_value = instances
     scale_set = vmss_provider.provide_scale_set()
 
     # fire
     result = fetch_instances(
-        scale_set, [{'instanceId': '0'}, {'instanceId': '1'}, {'instanceId': '2'}], None, None)
+        scale_set, [{'instance_id': '0'}, {'instance_id': '1'}, {'instance_id': '2'}], None, None)
 
     # assert
     assert len(result) == 3
-    assert result[0].get('name') == 'chaos-machine'
-    assert result[0].get('instanceId') == '0'
-    assert result[1].get('name') == 'chaos-machine'
-    assert result[1].get('instanceId') == '1'
-    assert result[2].get('name') == 'chaos-machine'
-    assert result[2].get('instanceId') == '2'
+    assert result[0].get('name') == 'chaos-pool_0'
+    assert result[0].get('instance_id') == '0'
+    assert result[1].get('name') == 'chaos-pool_1'
+    assert result[1].get('instance_id') == '1'
+    assert result[2].get('name') == 'chaos-pool_2'
+    assert result[2].get('instance_id') == '2'
 
 
 @patch.object(chaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
 def test_empty_fetch_instances_with_instance_criteria(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
-    instance_0['instanceId'] = '0'
+    instance_0['instance_id'] = '0'
     instance_1 = vmss_provider.provide_instance()
-    instance_1['instanceId'] = '1'
+    instance_1['instance_id'] = '1'
     instance_2 = vmss_provider.provide_instance()
-    instance_2['instanceId'] = '2'
+    instance_2['instance_id'] = '2'
     instances = [instance_0, instance_1, instance_2]
     mocked_fetch_instances.return_value = instances
     scale_set = vmss_provider.provide_scale_set()
@@ -145,6 +151,6 @@ def test_empty_fetch_instances_with_instance_criteria(mocked_fetch_instances):
     # fire
     with pytest.raises(FailedActivity) as x:
         fetch_instances(
-            scale_set, [{'instanceId': '99'}, {'instanceId': '100'}, {'instanceId': '101'}], None, None)
+            scale_set, [{'instance_id': '99'}, {'instance_id': '100'}, {'instance_id': '101'}], None, None)
 
         assert "No VMSS instance" in x.value


### PR DESCRIPTION
This commit enables the ctk-azure to output results from activities. For
now the activities of concern are the aks/machine actions and the vmss
actions.

In the same commit I fixed minor issues such as the MANIFEST that was
leading to a wrong path of the compute scripts.

Resolves: #112

Signed-off-by: Bugra <bugra.derre@gmail.com>