### PR TITLE
Added new Managemant clinet function which calls WebSiteManagementClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased][]
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.8.3...HEAD
 
+### Added
+
+-   Individual Azure managemnt clients for website and compute resources
+
+### Removed
+
+-   Removed common init_client
+
 ## [0.8.3][] - 2020-05-14
 
 [0.8.3]: https://github.com/chaostoolkit-incubator/chaostoolkit-azure/compare/0.8.2...0.8.3

--- a/chaosazure/__init__.py
+++ b/chaosazure/__init__.py
@@ -5,6 +5,7 @@
 from typing import List
 
 from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.web import WebSiteManagementClient
 from azure.mgmt.resourcegraph import ResourceGraphClient
 from chaoslib.discovery import (discover_actions, discover_probes,
                                 initialize_discovery_result)
@@ -16,8 +17,8 @@ from chaosazure.auth import auth
 from chaosazure.common.config import load_configuration, load_secrets
 
 __all__ = [
-    "discover", "__version__", "init_client",
-    "init_resource_graph_client"
+    "discover", "__version__", "init_compute_management_client",
+    "init_website_management_client", "init_resource_graph_client"
 ]
 __version__ = '0.8.3'
 
@@ -34,10 +35,13 @@ def discover(discover_system: bool = True) -> Discovery:
     return discovery
 
 
-def init_client(
+def init_compute_management_client(
         experiment_secrets: Secrets,
         experiment_configuration: Configuration) -> ComputeManagementClient:
-
+    """
+    Initializes Compute management client for virtual machine,
+    and virtual machine scale sets resources under Azure Resource manager.
+    """
     secrets = load_secrets(experiment_secrets)
     configuration = load_configuration(experiment_configuration)
     with auth(secrets) as authentication:
@@ -50,9 +54,30 @@ def init_client(
         return client
 
 
+def init_website_management_client(
+        experiment_secrets: Secrets,
+        experiment_configuration: Configuration) -> WebSiteManagementClient:
+    """
+    Initializes Website management client for webapp resource under Azure
+    Resource manager.
+    """
+    secrets = load_secrets(experiment_secrets)
+    configuration = load_configuration(experiment_configuration)
+    with auth(secrets) as authentication:
+        base_url = secrets.get('cloud').endpoints.resource_manager
+        client = WebSiteManagementClient(
+            credentials=authentication,
+            subscription_id=configuration.get('subscription_id'),
+            base_url=base_url)
+
+        return client
+
+
 def init_resource_graph_client(
         experiment_secrets: Secrets) -> ResourceGraphClient:
-
+    """
+    Initializes Resource Graph client.
+    """
     secrets = load_secrets(experiment_secrets)
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager

--- a/chaosazure/common/compute/command.py
+++ b/chaosazure/common/compute/command.py
@@ -3,7 +3,7 @@ import os
 from chaoslib.exceptions import FailedActivity, InterruptExecution
 from logzero import logger
 
-from chaosazure import init_client
+from chaosazure import init_compute_management_client
 from chaosazure.machine.constants import OS_LINUX, OS_WINDOWS, RES_TYPE_VM
 from chaosazure.vmss.constants import RES_TYPE_VMSS_VM
 
@@ -41,7 +41,7 @@ def prepare(compute: dict, script: str):
 
 def run(resource_group: str, compute: dict, timeout: int, parameters: dict,
         secrets, configuration):
-    client = init_client(secrets, configuration)
+    client = init_compute_management_client(secrets, configuration)
 
     compute_type = compute.get('type').lower()
     if compute_type == RES_TYPE_VMSS_VM.lower():

--- a/chaosazure/machine/actions.py
+++ b/chaosazure/machine/actions.py
@@ -4,7 +4,7 @@ from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
-from chaosazure import init_client
+from chaosazure import init_compute_management_client
 from chaosazure.common import cleanse
 from chaosazure.common.compute import command
 from chaosazure.machine.constants import RES_TYPE_VM
@@ -521,4 +521,4 @@ def __fetch_machines(filter, configuration, secrets) -> []:
 
 
 def __compute_mgmt_client(secrets, configuration):
-    return init_client(secrets, configuration)
+    return init_compute_management_client(secrets, configuration)

--- a/chaosazure/vmss/actions.py
+++ b/chaosazure/vmss/actions.py
@@ -3,7 +3,7 @@ from typing import Iterable, Mapping
 from chaoslib import Configuration, Secrets
 from logzero import logger
 
-from chaosazure import init_client
+from chaosazure import init_compute_management_client
 from chaosazure.common import cleanse
 from chaosazure.common.compute import command
 from chaosazure.vmss.fetcher import fetch_vmss, fetch_instances
@@ -48,7 +48,7 @@ def delete_vmss(filter: str = None,
         for instance in instances:
             logger.debug(
                 "Deleting instance: {}".format(instance['name']))
-            client = init_client(secrets, configuration)
+            client = init_compute_management_client(secrets, configuration)
             client.virtual_machine_scale_set_vms.delete(
                 scale_set['resourceGroup'],
                 scale_set['name'],
@@ -90,7 +90,7 @@ def restart_vmss(filter: str = None,
         for instance in instances:
             logger.debug(
                 "Restarting instance: {}".format(instance['name']))
-            client = init_client(secrets, configuration)
+            client = init_compute_management_client(secrets, configuration)
             client.virtual_machine_scale_set_vms.restart(
                 scale_set['resourceGroup'],
                 scale_set['name'],
@@ -154,7 +154,7 @@ def stop_vmss(filter: str = None,
         for instance in instances:
             logger.debug(
                 "Stopping instance: {}".format(instance['name']))
-            client = init_client(secrets, configuration)
+            client = init_compute_management_client(secrets, configuration)
             client.virtual_machine_scale_set_vms.power_off(
                 scale_set['resourceGroup'],
                 scale_set['name'],
@@ -196,7 +196,7 @@ def deallocate_vmss(filter: str = None,
         for instance in instances:
             logger.debug(
                 "Deallocating instance: {}".format(instance['name']))
-            client = init_client(secrets, configuration)
+            client = init_compute_management_client(secrets, configuration)
             client.virtual_machine_scale_set_vms.deallocate(
                 scale_set['resourceGroup'],
                 scale_set['name'],

--- a/chaosazure/vmss/fetcher.py
+++ b/chaosazure/vmss/fetcher.py
@@ -5,7 +5,7 @@ from chaoslib import Configuration, Secrets
 from chaoslib.exceptions import FailedActivity
 from logzero import logger
 
-from chaosazure import init_client
+from chaosazure import init_compute_management_client
 from chaosazure.common.resources.graph import fetch_resources
 from chaosazure.vmss.constants import RES_TYPE_VMSS
 
@@ -62,7 +62,7 @@ def fetch_vmss(filter, configuration, secrets) -> List[dict]:
 #############################################################################
 def __fetch_vmss_instances(choice, configuration, secrets) -> List[Dict]:
     vmss_instances = []
-    client = init_client(secrets, configuration)
+    client = init_compute_management_client(secrets, configuration)
     pages = client.virtual_machine_scale_set_vms.list(
         choice['resourceGroup'], choice['name'])
     first_page = pages.advance_page()

--- a/chaosazure/webapp/actions.py
+++ b/chaosazure/webapp/actions.py
@@ -4,7 +4,7 @@ from chaoslib import Secrets, Configuration
 from chaoslib.exceptions import FailedActivity
 from logzero import logger
 
-from chaosazure import init_client
+from chaosazure import init_website_management_client
 from chaosazure.common.resources.graph import fetch_resources
 from chaosazure.webapp.constants import RES_TYPE_WEBAPP
 
@@ -33,7 +33,7 @@ def stop_webapp(filter: str = None,
     choice = __fetch_webapp_at_random(filter, configuration, secrets)
 
     logger.debug("Stopping web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
+    client = init_website_management_client(secrets, configuration)
     client.web_apps.stop(choice['resourceGroup'], choice['name'])
 
 
@@ -58,7 +58,7 @@ def restart_webapp(filter: str = None,
     choice = __fetch_webapp_at_random(filter, configuration, secrets)
 
     logger.debug("Restarting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
+    client = init_website_management_client(secrets, configuration)
     client.web_apps.restart(choice['resourceGroup'], choice['name'])
 
 
@@ -83,7 +83,7 @@ def start_webapp(filter: str = None,
     choice = __fetch_webapp_at_random(filter, configuration, secrets)
 
     logger.debug("Starting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
+    client = init_website_management_client(secrets, configuration)
     client.web_apps.start(choice['resourceGroup'], choice['name'])
 
 
@@ -111,7 +111,7 @@ def delete_webapp(filter: str = None,
     choice = __fetch_webapp_at_random(filter, configuration, secrets)
 
     logger.debug("Deleting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
+    client = init_website_management_client(secrets, configuration)
     client.web_apps.delete(choice['resourceGroup'], choice['name'])
 
 

--- a/tests/vmss/test_vmss_actions.py
+++ b/tests/vmss/test_vmss_actions.py
@@ -8,7 +8,7 @@ from tests.data import config_provider, secrets_provider, vmss_provider
 
 @patch('chaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
-@patch('chaosazure.vmss.actions.init_client', autospec=True)
+@patch('chaosazure.vmss.actions.init_compute_management_client', autospec=True)
 def test_deallocate_vmss(client, fetch_instances, fetch_vmss):
     scale_set = vmss_provider.provide_scale_set()
     scale_sets = [scale_set]
@@ -25,7 +25,7 @@ def test_deallocate_vmss(client, fetch_instances, fetch_vmss):
 
 @patch('chaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
-@patch('chaosazure.vmss.actions.init_client', autospec=True)
+@patch('chaosazure.vmss.actions.init_compute_management_client', autospec=True)
 def test_stop_vmss(client, fetch_instances, fetch_vmss):
     scale_set = vmss_provider.provide_scale_set()
     scale_sets = [scale_set]
@@ -41,7 +41,7 @@ def test_stop_vmss(client, fetch_instances, fetch_vmss):
 
 @patch('chaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
-@patch('chaosazure.vmss.actions.init_client', autospec=True)
+@patch('chaosazure.vmss.actions.init_compute_management_client', autospec=True)
 def test_restart_vmss(client, fetch_instances, fetch_vmss):
     scale_set = vmss_provider.provide_scale_set()
     scale_sets = [scale_set]
@@ -57,7 +57,7 @@ def test_restart_vmss(client, fetch_instances, fetch_vmss):
 
 @patch('chaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('chaosazure.vmss.actions.fetch_instances', autospec=True)
-@patch('chaosazure.vmss.actions.init_client', autospec=True)
+@patch('chaosazure.vmss.actions.init_compute_management_client', autospec=True)
 def test_delete_vmss(client, fetch_instances, fetch_vmss):
     scale_set = vmss_provider.provide_scale_set()
     scale_sets = [scale_set]

--- a/tests/webapp/test_webapp_actions.py
+++ b/tests/webapp/test_webapp_actions.py
@@ -21,7 +21,7 @@ resource = {
 
 
 @patch('chaosazure.webapp.actions.fetch_webapps', autospec=True)
-@patch('chaosazure.webapp.actions.init_client', autospec=True)
+@patch('chaosazure.webapp.actions.init_website_management_client', autospec=True)
 def test_stop_webapp(init, fetch):
     client = MagicMock()
     init.return_value = client
@@ -37,7 +37,7 @@ def test_stop_webapp(init, fetch):
 
 
 @patch('chaosazure.webapp.actions.fetch_webapps', autospec=True)
-@patch('chaosazure.webapp.actions.init_client', autospec=True)
+@patch('chaosazure.webapp.actions.init_website_management_client', autospec=True)
 def test_restart_webapp(init, fetch):
     client = MagicMock()
     init.return_value = client
@@ -53,7 +53,7 @@ def test_restart_webapp(init, fetch):
 
 
 @patch('chaosazure.webapp.actions.fetch_webapps', autospec=True)
-@patch('chaosazure.webapp.actions.init_client', autospec=True)
+@patch('chaosazure.webapp.actions.init_website_management_client', autospec=True)
 def test_start_webapp(init, fetch):
     client = MagicMock()
     init.return_value = client
@@ -69,7 +69,7 @@ def test_start_webapp(init, fetch):
 
 
 @patch('chaosazure.webapp.actions.fetch_webapps', autospec=True)
-@patch('chaosazure.webapp.actions.init_client', autospec=True)
+@patch('chaosazure.webapp.actions.init_website_management_client', autospec=True)
 def test_delete_webapp(init, fetch):
     client = MagicMock()
     init.return_value = client


### PR DESCRIPTION
This fixes the handling of the below-attached Image.

![error](https://user-images.githubusercontent.com/40433943/92743294-0a374c80-f39e-11ea-8cc8-ca9ef50677aa.PNG)

Created a Sperate Function which handles WebSiteManagementClient and now this function is called by all actions present in the Webapp module.

* Changed rephrased existing init_client to init_compute_client which is used by all the modules except the Webapp module
* Created init_website_management_client which is used by Webapp module