### PR TITLE
Add scopes to PostgreSQL auth

### DIFF
--- a/chaosazure/__init__.py
+++ b/chaosazure/__init__.py
@@ -72,8 +72,10 @@ def init_postgresql_flexible_management_client(
     configuration = load_configuration(experiment_configuration)
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager
+        scopes = [base_url + "/.default"]
         client = PostgreSQLFlexibleManagementClient(
             credential=authentication,
+            credential_scopes=scopes,
             subscription_id=configuration.get('subscription_id'),
             base_url=base_url)
 
@@ -91,8 +93,10 @@ def init_postgresql_management_client(
     configuration = load_configuration(experiment_configuration)
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager
+        scopes = [base_url + "/.default"]
         client = PostgreSQLManagementClient(
             credential=authentication,
+            credential_scopes=scopes,
             subscription_id=configuration.get('subscription_id'),
             base_url=base_url)
 


### PR DESCRIPTION
As per @xpdable findings, we need to specify the client scope to make a successful auth in various Azure regions of the world.

@Lunik now that I've merged your recent PR, could you please checkout the main branch and try see if I haven't broken anything? It should be transparent in theory.

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>